### PR TITLE
Remove unused props assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ function renderJsx (opts, callback, error, xml) {
         root = xml[opts.tag] = root;
         delete xml[tagName];
         tagName = opts.tag;
-        props = root.$ = {};
     }
 
     var props = assign(sanitize(root).$ || {}, opts.attrs);


### PR DESCRIPTION
Props is assigned here but immediately reassigned on line 41. This was introduced here: https://github.com/jhamlet/svg-react-loader/commit/1103a029ef09ad74303949e8432a20a982d6e8c7#diff-168726dbe96b3ce427e7fedce31bb0bcR57

I think this line can be removed since after changing the tag, the assignment with `assign` after the conditional is always correct :) 
 