### PR TITLE
Add support for a custom SVG root element

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ already assigned to the tag, the value here will override that. ex.:
 `reactDom`: A string to require an alternaitve 'react-dom' module. ex.:
 `?reactDom=react`
 
+`root`: A pipe delimited list of possible root XML nodes to use instead of the one found in the source file. ex.:
+`?root=path|polygon`
+
 
 Dependencies
 ------------
@@ -97,7 +100,7 @@ Babel presets for your loader within your webpack configuration:
 ~~~js
 // file: webpack.config.js
 module.exports = {
-    
+
     loaders: [
         { test: /\.svg$/, loader: 'babel?presets[]=es2015,presets[]=react!svg-react' }
     ],
@@ -121,7 +124,7 @@ webpack configuration that points to your installed version of `react`:
 ~~~js
 // file: webpack.config.js
 module.exports = {
-    
+
     loaders: [
         { test: /\.svg$/, loader: 'babel!svg-react' }
     ],
@@ -153,7 +156,7 @@ License
 -------
 
 > Copyright (c) 2015 Jerry Hamlet <jerry@hamletink.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person
 > obtaining a copy of this software and associated documentation
 > files (the "Software"), to deal in the Software without
@@ -162,12 +165,12 @@ License
 > copies of the Software, and to permit persons to whom the
 > Software is furnished to do so, subject to the following
 > conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > The Software shall be used for Good, not Evil.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 > OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/index.js
+++ b/index.js
@@ -26,11 +26,20 @@ function readTemplate (callback, filepath) {
     });
 }
 
+function isArray(obj) {
+    return Object.prototype.toString.call(obj) === '[object Array]';
+}
+
 function getCustomRoot(xml, roots, depth, source) {
-    if (depth >= 3) {
+    if (depth >= 10) {
         return null;
     }
-    var keyList = keys(xml);
+
+    if (isArray(xml)) {
+        xml = xml[0];
+    }
+
+    var keyList = keys(xml).filter(key => key !== '$');
     for (var x = 0; x < keyList.length; x++) {
         var key = keyList[x];
         for (var y = 0; y < roots.length; y++) {
@@ -44,7 +53,7 @@ function getCustomRoot(xml, roots, depth, source) {
     }
     for (var i = 0; i < keyList.length; i++) {
         var key = xml[keyList[i]];
-        var customRoot = getCustomRoot(key, roots, depth + 1);
+        var customRoot = getCustomRoot(key, roots, depth + 1, source);
         if (customRoot != null) {
             return customRoot;
         }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ function getCustomRoot(xml, roots, depth, source) {
         for (var y = 0; y < roots.length; y++) {
             var root = roots[y];
             if (key === root) {
-                return xml[root];
+                var obj = {};
+                obj[root] = xml[root][0];
+                return obj;
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function renderJsx (opts, callback, error, xml) {
     var props = assign(sanitize(root).$ || {}, opts.attrs);
 
     var xmlBuilder = new xml2js.Builder({ headless: true });
-    var xmlSrc = xmlBuilder.buildObject(root);
+    var xmlSrc = xmlBuilder.buildObject(opts.root ? root : xml);
     var component = opts.tmpl({
         reactDom:      opts.reactDom,
         tagName:       opts.tagName || tagName,

--- a/index.js
+++ b/index.js
@@ -9,12 +9,20 @@ var assign   = require('lodash/assign');
 var keys     = require('lodash/keys');
 var partial  = require('lodash/partial');
 
+var cachedTemplate = null;
+
 function readTemplate (callback, filepath) {
+    if (cachedTemplate != null) {
+        callback(cachedTemplate);
+        return;
+    }
+
     fs.readFile(filepath, 'utf8', function (error, contents) {
         if (error) {
             throw error;
         }
-        callback(template(contents));
+        cachedTemplate = template(contents);
+        callback(cachedTemplate);
     });
 }
 

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -86,7 +86,7 @@ describe('svg-react-loader', function () {
         });
     });
 
-    it.only('should handle text elements', function (done) {
+    it('should handle text elements', function (done) {
         var filename = './svg/text.svg';
 
         invoke(read(filename), {

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -47,9 +47,9 @@ describe('svg-react-loader', function () {
                     throw error;
                 }
 
-                console.log(babel.transform(result, {
-                    presets: ['es2015', 'react']
-                }).code);
+                // console.log(babel.transform(result, {
+                //     presets: ['es2015', 'react']
+                // }).code);
                 done();
             },
             query: '?reactDom=react',
@@ -70,16 +70,17 @@ describe('svg-react-loader', function () {
                 var src = babel.transform(result, {
                     presets: ['es2015', 'react']
                 }).code;
-                console.log(src);
-                fs.writeFileSync(__dirname + '/temp', src);
-                var el = react.createElement(require(__dirname + '/temp'));
+                src = src.replace('svg-react-loader/helpers', '../helpers');
+                // console.log(src);
+                fs.writeFileSync(__dirname + '/temp-styles', src);
+                var el = react.createElement(require(__dirname + '/temp-styles'));
                 var html = react.renderToStaticMarkup(el);
 
                 // var el = react.createElement('style');
                 // var html = react.renderToStaticMarkup(el);
 
-                console.log(html);
-                fs.unlink(__dirname + '/temp');
+                // console.log(html);
+                fs.unlink(__dirname + '/temp-styles');
                 done();
             },
             resourcePath: filename
@@ -98,16 +99,17 @@ describe('svg-react-loader', function () {
                 var src = babel.transform(result, {
                     presets: ['es2015', 'react']
                 }).code;
-                console.log(src);
-                fs.writeFileSync(__dirname + '/temp', src);
-                var el = react.createElement(require(__dirname + '/temp'));
+                src = src.replace('svg-react-loader/helpers', '../helpers');
+                // console.log(src);
+                fs.writeFileSync(__dirname + '/temp-text', src);
+                var el = react.createElement(require(__dirname + '/temp-text'));
                 var html = react.renderToStaticMarkup(el);
 
                 // var el = react.createElement('style');
                 // var html = react.renderToStaticMarkup(el);
 
-                console.log(html);
-                fs.unlink(__dirname + '/temp');
+                // console.log(html);
+                fs.unlink(__dirname + '/temp-text');
                 done();
             },
             resourcePath: filename
@@ -135,6 +137,36 @@ describe('svg-react-loader', function () {
                     height: 'auto'
                 }
             })
+        });
+    });
+
+    it('should handle the root option', function(done) {
+        var filename = './svg/text.svg';
+
+        invoke(read(filename), {
+            query: '?root=text',
+            callback: function (error, result) {
+                if (error) {
+                    throw error;
+                }
+
+                var src = babel.transform(result, {
+                    presets: ['es2015', 'react']
+                }).code;
+                src = src.replace('svg-react-loader/helpers', '../helpers');
+                // console.log(src);
+                fs.writeFileSync(__dirname + '/temp-root', src);
+                var el = react.createElement(require(__dirname + '/temp-root'));
+                var html = react.renderToStaticMarkup(el);
+
+                // var el = react.createElement('style');
+                // var html = react.renderToStaticMarkup(el);
+
+                fs.unlink(__dirname + '/temp-root');
+                html.should.equal('<text x="20" y="20"></text>');
+                done();
+            },
+            resourcePath: filename
         });
     });
 });

--- a/utility/template.txt
+++ b/utility/template.txt
@@ -1,5 +1,5 @@
 var React = require('react');
-var helpers = require('../helpers')(require('<%= reactDom %>'));
+var helpers = require('svg-react-loader/helpers')(require('<%= reactDom %>'));
 
 module.exports = React.createClass({
 

--- a/utility/template.txt
+++ b/utility/template.txt
@@ -1,5 +1,5 @@
 var React = require('react');
-var helpers = require('svg-react-loader/helpers')(require('<%= reactDom %>'));
+var helpers = require('../helpers')(require('<%= reactDom %>'));
 
 module.exports = React.createClass({
 


### PR DESCRIPTION
This PR adds the option to configure an optional `root` element(s) to replace whichever root element exists in the svg file.

This is helpful if the source svg files aren't standardized or contain unnecessary pieces of data (like if they were exported from Sketch). Specifying a root (like `path`) allows you to consume only the necessary parts of the svg file and wrap them in a standard `<svg>` template. 

I also added an optimization around fetching the template file - it's constantly refetched from disk for each svg so I added a variable cache to improve that performance.

I added tests for the `root` changes too.
