### PR TITLE
Use getOptions instead of parseQuery for compat with webpack2

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -21,8 +21,8 @@ module.exports = function svgReactLoader (source) {
     var callback  = context.async();
     var ctxOpts   = context.svgReactLoader;
     var filters   = ctxOpts && ctxOpts.filters || [];
-    var query     = lutils.parseQuery(context.query);
-    var rsrcQuery = lutils.parseQuery(context.resourceQuery);
+    var query     = lutils.getOptions(context.query);
+    var rsrcQuery = lutils.getOptions(context.resourceQuery);
     var params    = R.merge(query, rsrcQuery);
 
     var displayName   = params.name || titleCaseBasename(context.resourcePath);


### PR DESCRIPTION
parseQuery was removed from loader-utils [here](https://github.com/webpack/loader-utils/pull/65/files). These changes update the loader to work against the new api.