### PR TITLE
handle file names with dots property

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ the resource will override those given for the loader.
   is a simple object of `propname: 'translatedname'`
 
 * `xmlnsTest`: A regular expression used to remove non-supported xmlns
-  attributes. Default is /^xmlns(Xlink)?$/
+  attributes. Default is `/^xmlns(Xlink)?$/`
+
+* `titleCaseDelim`: A regular expression used to generate component's name. It
+  would be ignore if `name` was set.
+  Default is `/[._-]/`
 
 #### Examples
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,7 +2,7 @@ var R          = require('ramda');
 var path       = require('path');
 var lutils     = require('loader-utils');
 var svgToReact = require('./index');
-var titleCase  = require('./util/title-case')(/[_-]/);
+var titleCase  = require('./util/title-case')(/[._-]/);
 
 function titleCaseBasename (filepath) {
     var ext = path.extname(filepath);

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,12 +2,12 @@ var R          = require('ramda');
 var path       = require('path');
 var lutils     = require('loader-utils');
 var svgToReact = require('./index');
-var titleCase  = require('./util/title-case')(/[._-]/);
+var titleCase  = require('./util/title-case');
 
-function titleCaseBasename (filepath) {
+function titleCaseBasename (filepath, delim) {
     var ext = path.extname(filepath);
     var base = path.basename(filepath, ext);
-    return titleCase(base);
+    return titleCase(delim)(base);
 }
 
 function mapKeyValue (acc, cur) {
@@ -25,13 +25,14 @@ module.exports = function svgReactLoader (source) {
     var rsrcQuery = context.resourceQuery && lutils.parseQuery(context.resourceQuery);
     var params    = R.merge(query || {}, rsrcQuery || {});
 
-    var displayName   = params.name || titleCaseBasename(context.resourcePath);
-    var tagname       = params.tag;
-    var tagprops      = params.props || params.attrs;
-    var propsMap      = params.propsMap || {};
-    var raw           = params.raw;
-    var xmlnsTest     = params.xmlnsTest;
-    var classIdPrefix = params.classIdPrefix || false;
+    var titleCaseDelim = params.titleCaseDelim || /[._-]/;
+    var displayName    = params.name || titleCaseBasename(context.resourcePath, titleCaseDelim);
+    var tagname        = params.tag;
+    var tagprops       = params.props || params.attrs;
+    var propsMap       = params.propsMap || {};
+    var raw            = params.raw;
+    var xmlnsTest      = params.xmlnsTest;
+    var classIdPrefix  = params.classIdPrefix || false;
 
     context.cacheable();
 

--- a/test/unit/utility/camel-case.js
+++ b/test/unit/utility/camel-case.js
@@ -24,6 +24,11 @@ describe('svg-react-loader/lib/util/camel-case', () => {
             delim: null,
             text: 'foo-bar-baz',
             result: 'fooBarBaz'
+        },
+        {
+            delim: /[.:-]/g,
+            text: 'foo.bar.baz',
+            result: 'fooBarBaz'
         }
     ];
 


### PR DESCRIPTION
For issue #49

Let the title-case method can work with dots. It would translate `minus.inline.svg` to `MinusInline`

- [x] Add test in `test/unit/utility/title-case.js`
- [x] Add an option to the loader `titleCaseDelim=[RegExp]`

[update 1]: Add todo list 