### PR TITLE
Support webpack 2 configuration

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -21,7 +21,7 @@ module.exports = function svgReactLoader (source) {
     var callback  = context.async();
     var ctxOpts   = context.svgReactLoader;
     var filters   = ctxOpts && ctxOpts.filters || [];
-    var query     = context.query && lutils.parseQuery(context.query);
+    var query     = lutils.getOptions(context);
     var rsrcQuery = context.resourceQuery && lutils.parseQuery(context.resourceQuery);
     var params    = R.merge(query || {}, rsrcQuery || {});
 


### PR DESCRIPTION
For webpack 2. Just pass `const options = loaderUtils.getOptions(this);` to get options.

ref: https://github.com/webpack/loader-utils#getoptions

relative: #73 