### PR TITLE
Fix element classNames/ids for objects when using classIdPrefix property

### DIFF
--- a/lib/sanitize/filters/prefix-style-class-id.js
+++ b/lib/sanitize/filters/prefix-style-class-id.js
@@ -26,9 +26,10 @@ function processStyles (opts, source) {
                         replace(
                             CLASSNAME_OR_ID_SELECTOR_REGEX,
                             function (match, pre, post) {
-                                var newname = pre + opts.prefix + post;
-                                opts.cache[post] = newname;
-                                return newname;
+                                // Set the cached version to not include the prefix (the dot) so that the className or id
+                                // is 'className' instead of '.className'
+                                opts.cache[post] = opts.prefix + post;
+                                return pre + opts.prefix + post;
                             }
                         );
                 });

--- a/test/unit/xml/parse.js
+++ b/test/unit/xml/parse.js
@@ -177,7 +177,7 @@ describe('svg-react-loader/lib/xml/parse', () => {
                                                 {
                                                     tagname: 'path',
                                                     props: {
-                                                        className: ".styles-test__st0",
+                                                        className: "styles-test__st0",
                                                         d: "M14.5,18v2h21v-2H14.5z M14.5,26h21v-2h-21V26z M14.5,32h21v-2h-21V32z"
                                                     }
                                                 }


### PR DESCRIPTION
Hi @jhamlet, thanks for making this loader!

I'm taking advantage of the classIdPrefix property as I have multiple auto-generated svgs with conflicting class names being loaded into the same file and ran into an issue where the class styles are not showing up in my application. I think the issue is because the "." is included in both the style names and in the actual class property for the rendered element.

This PR seemed to fix the issue for me -- although not sure if this is actually the right way to go about fixing it. (it assumes the styles are calculated sequentially prior to the elements, but I think that's already assumed given the cache?) Let me know if there's a better way to do this. 

I also updated the test to match the new output.