### PR TITLE
Create unique ID prefix within SVGs to prevent ID collisions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Jerry Hamlet <jerry@hamletink.com> (http://hamletink.com/)
+William Brinkert <wfbrinkert@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,1 @@
 Jerry Hamlet <jerry@hamletink.com> (http://hamletink.com/)
-William Brinkert <wfbrinkert@gmail.com>

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ are acted on by the loader version of `svg-react`.
 
 ### Notes
 
-> This fork has an added filter which creates unique IDs and mask, fill, and xlink:href
-> references to those IDs.
+> This fork has an added filter which creates 'unique' IDs and mask, fill, and xlink:href
+> references to those IDs by prefixing the filename.
 > As of version 0.4.0, `svg-react-loader` no longer requires `babel` to
 > transpile the generated code. Everything is returned as an ES5-7 compatible
 > module, and the component is just a

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ other loaders before `svg-react` to alter/update/remove nodes before reaching
 In addition, the new [filters](#filters) API allows for additional ways to
 modify the generated SVG Component. This allows `svg-react` to also be used as a
 pre-loader (with `filters` and `raw=true` params) for modifying SVGs before they
-are acted on by the loader version of `svg-react`.
+are acted on by the loader version of `svg-react`. 
 
 ### Notes
 
+> This fork has an added filter which creates unique IDs and mask, fill, and xlink:href
+> references to those IDs.
 > As of version 0.4.0, `svg-react-loader` no longer requires `babel` to
 > transpile the generated code. Everything is returned as an ES5-7 compatible
 > module, and the component is just a
@@ -93,6 +95,10 @@ the resource will override those given for the loader.
   blocks, or within `className` properties, with. If indicated without a string,
   the file's basename will be used as a prefix.
 
+* `uniqueIdPrefix`: When set to `true` will prefix the filename to the IDs and
+  references within the SVG, solving the problem of ID collision when multiple
+  SVGs are used on the same page.
+
 * `raw`: If set to `true` will output the parsed object tree repesenting the SVG
   as a JSON string. Otherwise, returns a string of JavaScript that represents
   the component's module.
@@ -121,6 +127,7 @@ module: {
             loader: 'svg-react-loader',
             query: {
                 classIdPrefix: '[name]-[hash:8]__',
+                uniqueIdPrefix: true,
                 filters: [
                     function (value) {
                         // ...
@@ -204,6 +211,7 @@ Report an Issue
 
 * [Bugs](http://github.com/jhamlet/svg-react-loader/issues)
 * Contact the author: <jerry@hamletink.com>
+* For issues with the generation of unique ID prefixes, please contact <wfbrinkert@gmail.com>
 
 
 License

--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ modify the generated SVG Component. This allows `svg-react` to also be used as a
 pre-loader (with `filters` and `raw=true` params) for modifying SVGs before they
 are acted on by the loader version of `svg-react`. 
 
-This fork has an added filter which creates 'unique' IDs and mask, fill, and xlink:href
+There is a filter which creates 'unique' IDs and mask, fill, and xlink:href
 references to those IDs by prefixing the SVG filename. This solves a common problem
 encountered when loading multiple SVGs onto the same page: if the IDs within the different
 SVGs are the same, there will be ID collisions which will cause a variety of issues with 
 the rendering of the SVG components. Although there are plugins available for [SVGO](https://github.com/svg/svgo)
 designed to solve this problem, the solution implemented here provides another way to
-avoid ID collision issues on SVGs. Although this version is not yet available via NPM, 
-you may still include it in your project by placing `"svg-react-loader": "git+https://github.com/SilverFox70/svg-react-loader.git"` into your `package.json` file and running `npm install`. In order to get a clean install
-you may find it necessary to first delete your `node_modules` folder *before* running npm install again.
+avoid ID collision issues on SVGs.
 
 ### Notes
 
@@ -40,10 +38,6 @@ you may find it necessary to first delete your `node_modules` folder *before* ru
 
 Installation
 ------------
-> Please note that this fork is NOT yet available on NPM and therefore
-> running the command below will not get you this fork of the project.
-> This instruction is being kept for legacy purposes and will be removed
-> or updated when and if this fork becomes available on NPM.
 ~~~
 % npm install --save-dev svg-react-loader
 ~~~

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ modify the generated SVG Component. This allows `svg-react` to also be used as a
 pre-loader (with `filters` and `raw=true` params) for modifying SVGs before they
 are acted on by the loader version of `svg-react`. 
 
+This fork has an added filter which creates 'unique' IDs and mask, fill, and xlink:href
+references to those IDs by prefixing the SVG filename. This solves a common problem
+encountered when loading multiple SVGs onto the same page: if the IDs within the different
+SVGs are the same, there will be ID collisions which will cause a variety of issues with 
+the rendering of the SVG components. Although there are plugins available for [SVGO](https://github.com/svg/svgo)
+designed to solve this problem, the solution implemented here provides another way to
+avoid ID collision issues on SVGs. Although this version is not yet available via NPM, 
+you may still include it in your project by placing `"svg-react-loader": "git+https://github.com/SilverFox70/svg-react-loader.git"` into your `package.json` file and running `npm install`. In order to get a clean install
+you may find it necessary to first delete your `node_modules` folder *before* running npm install again.
+
 ### Notes
 
-> This fork has an added filter which creates 'unique' IDs and mask, fill, and xlink:href
-> references to those IDs by prefixing the filename.
 > As of version 0.4.0, `svg-react-loader` no longer requires `babel` to
 > transpile the generated code. Everything is returned as an ES5-7 compatible
 > module, and the component is just a
@@ -32,7 +40,10 @@ are acted on by the loader version of `svg-react`.
 
 Installation
 ------------
-
+> Please note that this fork is NOT yet available on NPM and therefore
+> running the command below will not get you this fork of the project.
+> This instruction is being kept for legacy pruposes and will be removed
+> or updated when and if this fork becomes available on NPM.
 ~~~
 % npm install --save-dev svg-react-loader
 ~~~

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installation
 ------------
 > Please note that this fork is NOT yet available on NPM and therefore
 > running the command below will not get you this fork of the project.
-> This instruction is being kept for legacy pruposes and will be removed
+> This instruction is being kept for legacy purposes and will be removed
 > or updated when and if this fork becomes available on NPM.
 ~~~
 % npm install --save-dev svg-react-loader

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -33,6 +33,7 @@ module.exports = function svgReactLoader (source) {
     var raw            = params.raw;
     var xmlnsTest      = params.xmlnsTest;
     var classIdPrefix  = params.classIdPrefix || false;
+    var uniqueIdPrefix = params.uniqueIdPrefix || false;
 
     context.cacheable();
 
@@ -71,6 +72,8 @@ module.exports = function svgReactLoader (source) {
             typeof classIdPref === 'string' ?
                 lutils.interpolatename(context, classIdPrefix) :
                 classIdPrefix;
+
+    options.uniqueIdPrefix = uniqueIdPrefix === true ? displayName + '__' : '';
 
     if (params.filters) {
         filters =

--- a/lib/options.js
+++ b/lib/options.js
@@ -38,6 +38,13 @@ module.exports = function (opts) {
             }));
     }
 
+    if (options.uniqueIdPrefix) {
+        filters.
+            push(require('./sanitize/filters/unique-svg-ids')({
+                prefix: options.uniqueIdPrefix
+            }));
+    }
+
     if (options.root) {
         filters.
             push(require('./sanitize/filters/custom-root')(options.root));

--- a/lib/options.js
+++ b/lib/options.js
@@ -8,6 +8,7 @@ var DEFAULTS = {
         'for': 'htmlFor'
     },
     classIdPrefix: false,
+    uniqueIdPrefix: true,
     raw: false,
     xmlnsTest: /^xmlns(Xlink)?$/
 };

--- a/lib/sanitize/filters/unique-svg-ids.js
+++ b/lib/sanitize/filters/unique-svg-ids.js
@@ -1,0 +1,69 @@
+var R = require('ramda');
+var css = require('css');
+
+var DEFAULTS = {
+    prefix:      'filename-prefix__',
+};
+
+module.exports = function configureUniquePrefixId (opts) {
+    var options = R.merge(DEFAULTS, opts || {});
+    var cache   = options.cache = {};
+    var selectorRegex = /(url\(#)((\w|-)*)(\))/gmi;
+
+    _getMatches = (field, val) => {
+        var str = val.toString();
+        var matches = selectorRegex.exec(str);
+        // console.log(`-----------\n ${field} id is: ${opts.prefix + matches[2].replace('\"', "")}`);
+        selectorRegex.lastIndex = 0;
+        return opts.prefix + matches[2].replace('\"', "");
+
+    }
+
+    return function createUniquePrefixId (value) {
+        var hasID = false;
+        var path        = this.path;
+        // var isStyle     = isStyleNode(value);
+        // var hasChildren = hasChildrenKey(value);
+        // if(opts.prefix === "Bars__") console.log(`******* bars : ${JSON.stringify(value, null, 2)}`);
+        if (value.xlinkHref && value.xlinkHref.toString().startsWith("#")){
+            var newValue = "#" + opts.prefix + value.xlinkHref.toString().replace("#", "");
+            // console.log(`****** new xlink:href: ${newValue}`);
+            value.xlinkHref = newValue;
+            this.update(value);
+        }
+        if (value.id){
+            console.log(`value id: ${JSON.stringify(value.id, null, 2)}`);
+            var newValue = opts.prefix + value.id;
+            value.id = newValue;
+            // console.log(`#######################\n value here: ${JSON.stringify(value, null, 2)}`);
+            // console.log(`=======================\n before this:`);
+            // console.log(this);
+            // console.log(`new id: ${value.id}`);
+            this.update(value);
+            // console.log(`+++++++++++++++++++++++\n after this:`);
+            // console.log(this);
+            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
+            hasID = true;
+        }
+        if (value.fill && value.fill.toString().startsWith("url")){
+            // console.log(`value fill: ${JSON.stringify(value.fill, null, 2)}`);
+            var newValue = "url(#" + _getMatches('fill', value.fill) + ")";
+            // console.log(`new fill id: ${newValue}`);
+            value.fill = newValue;
+            this.update(value);
+            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
+            hasID = true;
+        }
+        if (value.mask && value.mask.toString().startsWith("url")){
+            // console.log(`value mask: ${JSON.stringify(value.mask, null, 2)}`);
+            var newValue = _getMatches('mask', value.mask);
+            var newValue = "url(#" + _getMatches('fill', value.mask) + ")";
+            // console.log(`new mask id: ${newValue}`);
+            value.mask = newValue;
+            this.update(value);
+            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
+            hasID = true;
+        }
+        // if (hasID) console.log(JSON.stringify(opts.prefix, null, 2));
+    };
+};

--- a/lib/sanitize/filters/unique-svg-ids.js
+++ b/lib/sanitize/filters/unique-svg-ids.js
@@ -1,6 +1,8 @@
 var R = require('ramda');
 var css = require('css');
 
+// This should be changed, because this isn't going to help
+// anyone in the case of a failure to get filename for prefix.
 var DEFAULTS = {
     prefix:      'filename-prefix__',
 };
@@ -29,7 +31,6 @@ module.exports = function configureUniquePrefixId (opts) {
 
         // Find all IDs and update with filename prefix
         if (value.id){
-            console.log(`value id: ${JSON.stringify(value.id, null, 2)}`);
             var newValue = opts.prefix + value.id;
             value.id = newValue;
             this.update(value);

--- a/lib/sanitize/filters/unique-svg-ids.js
+++ b/lib/sanitize/filters/unique-svg-ids.js
@@ -29,6 +29,13 @@ module.exports = function configureUniquePrefixId (opts) {
             this.update(value);
         }
 
+        // Find all href props and update
+        if (value.href && value.href.toString().startsWith("#")){
+            var newValue = "#" + opts.prefix + value.href.toString().replace("#", "");
+            value.href = newValue;
+            this.update(value);
+        }
+
         // Find all IDs and update with filename prefix
         if (value.id){
             var newValue = opts.prefix + value.id;
@@ -48,6 +55,13 @@ module.exports = function configureUniquePrefixId (opts) {
             var newValue = _getMatches('mask', value.mask);
             var newValue = "url(#" + _getMatches('fill', value.mask) + ")";
             value.mask = newValue;
+            this.update(value);
+        }
+
+        // Find all clipPath props and update with filename prefix
+        if (value.clipPath && value.clipPath.toString().startsWith("url")){
+            var newValue = "url(#" + _getMatches('clipPath', value.clipPath) + ")";
+            value.clipPath = newValue;
             this.update(value);
         }
     };

--- a/lib/sanitize/filters/unique-svg-ids.js
+++ b/lib/sanitize/filters/unique-svg-ids.js
@@ -10,60 +10,44 @@ module.exports = function configureUniquePrefixId (opts) {
     var cache   = options.cache = {};
     var selectorRegex = /(url\(#)((\w|-)*)(\))/gmi;
 
+    // Find the ID reference in items such as: "url(#a)" and return "a"
     _getMatches = (field, val) => {
         var str = val.toString();
         var matches = selectorRegex.exec(str);
-        // console.log(`-----------\n ${field} id is: ${opts.prefix + matches[2].replace('\"', "")}`);
         selectorRegex.lastIndex = 0;
+        // clean up and get rid of the quotes
         return opts.prefix + matches[2].replace('\"', "");
-
     }
 
     return function createUniquePrefixId (value) {
-        var hasID = false;
-        var path        = this.path;
-        // var isStyle     = isStyleNode(value);
-        // var hasChildren = hasChildrenKey(value);
-        // if(opts.prefix === "Bars__") console.log(`******* bars : ${JSON.stringify(value, null, 2)}`);
+        // Find all the xlink:href props with local references and update
         if (value.xlinkHref && value.xlinkHref.toString().startsWith("#")){
             var newValue = "#" + opts.prefix + value.xlinkHref.toString().replace("#", "");
-            // console.log(`****** new xlink:href: ${newValue}`);
             value.xlinkHref = newValue;
             this.update(value);
         }
+
+        // Find all IDs and update with filename prefix
         if (value.id){
             console.log(`value id: ${JSON.stringify(value.id, null, 2)}`);
             var newValue = opts.prefix + value.id;
             value.id = newValue;
-            // console.log(`#######################\n value here: ${JSON.stringify(value, null, 2)}`);
-            // console.log(`=======================\n before this:`);
-            // console.log(this);
-            // console.log(`new id: ${value.id}`);
             this.update(value);
-            // console.log(`+++++++++++++++++++++++\n after this:`);
-            // console.log(this);
-            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
-            hasID = true;
         }
+
+        // Find all fill props and update with filename prefix
         if (value.fill && value.fill.toString().startsWith("url")){
-            // console.log(`value fill: ${JSON.stringify(value.fill, null, 2)}`);
             var newValue = "url(#" + _getMatches('fill', value.fill) + ")";
-            // console.log(`new fill id: ${newValue}`);
             value.fill = newValue;
             this.update(value);
-            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
-            hasID = true;
         }
+
+        // Find all mask props and update with filename prefix
         if (value.mask && value.mask.toString().startsWith("url")){
-            // console.log(`value mask: ${JSON.stringify(value.mask, null, 2)}`);
             var newValue = _getMatches('mask', value.mask);
             var newValue = "url(#" + _getMatches('fill', value.mask) + ")";
-            // console.log(`new mask id: ${newValue}`);
             value.mask = newValue;
             this.update(value);
-            // console.log(`updated values: ${JSON.stringify(value, null, 2)}`);
-            hasID = true;
         }
-        // if (hasID) console.log(JSON.stringify(opts.prefix, null, 2));
     };
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jhamlet/svg-react-loader.git"
+    "url": "git+https://github.com/SilverFox70/svg-react-loader"
   },
   "keywords": [
     "webpack",
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/jhamlet/svg-react-loader/issues"
   },
-  "homepage": "https://github.com/jhamlet/svg-react-loader#readme",
+  "homepage": "https://github.com/SilverFox70/svg-react-loader#readme",
   "dependencies": {
     "css": "2.2.1",
     "loader-utils": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SilverFox70/svg-react-loader"
+    "url": "git+https://github.com/jhamlet/svg-react-loader.git"
   },
   "keywords": [
     "webpack",

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { mount } from 'enzyme';
 
 import SimpleSvg from '../../lib/loader.js?name=SimpleSvg!../samples/simple.svg';
-import StylesSvg from '../../lib/loader.js?classIdPrefix!../samples/styles.svg';
+import StylesSvg from '../../lib/loader.js?classIdPrefix&uniqueIdPrefix=true!../samples/styles.svg';
 import TextSvg from '../../lib/loader.js!../samples/text.svg';
 import ObjectSvg from '../../lib/loader.js!../samples/object.json';
 
@@ -61,7 +61,7 @@ describe('svg-react-loader', () => {
 
         const expectedProps = {
             version: "1.1",
-            id: "Layer_1",
+            id: "Styles__Layer_1",
             width: "50px",
             height: "50px",
             x: "0px",

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -7,6 +7,8 @@ import SimpleSvg from '../../lib/loader.js?name=SimpleSvg!../samples/simple.svg'
 import StylesSvg from '../../lib/loader.js?classIdPrefix&uniqueIdPrefix=true!../samples/styles.svg';
 import TextSvg from '../../lib/loader.js!../samples/text.svg';
 import ObjectSvg from '../../lib/loader.js!../samples/object.json';
+import ClipPathSvg from '../../lib/loader.js?uniqueIdPrefix=true!../samples/clippath.svg';
+import UseSvg from "../../lib/loader.js?uniqueIdPrefix=true!../samples/use.svg";
 
 require('should');
 
@@ -141,5 +143,42 @@ describe('svg-react-loader', () => {
             should.
             be.
             true;
+    });
+
+    it('clippath.svg', () => {
+        const wrapper = mount(<ClipPathSvg />);
+
+        const expectedClipPathProps = {
+            id: "Clippath__myClip"
+        }
+
+        const expectedUseProps = {
+            clipPath: "url(#Clippath__myClip)", 
+            xlinkHref: "#Clippath__heart", 
+            fill: "red"
+        }
+
+        getPropsMinusChildren(wrapper.find('clipPath')).
+            should.
+            eql(expectedClipPathProps);
+
+        getPropsMinusChildren(wrapper.find('use')).
+            should.
+            eql(expectedUseProps);
+    });
+
+    it('use.svg', () => {
+        const wrapper = mount(<UseSvg />);
+
+        const expectedProps = {
+            href: "#Use__myCircle", 
+            x: "20", 
+            fill: "white", 
+            stroke: "blue" 
+        }
+
+        getPropsMinusChildren(wrapper.find('use')).
+            should.
+            eql(expectedProps);
     });
 });

--- a/test/samples/clippath.svg
+++ b/test/samples/clippath.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 100 100">
+  <clipPath id="myClip">
+    <!--
+      Everything outside the circle will be
+      clipped and therefor invisible.
+    -->
+    <circle cx="40" cy="35" r="35" />
+  </clipPath>
+ 
+  <!-- The original black heart for reference -->
+  <path id="heart" d="M10,30 A20,20,0,0,1,50,30 A20,20,0,0,1,90,30 Q90,60,50,90 Q10,60,10,30 Z" />
+ 
+  <!--
+    Only the portion of the red heart
+    inside the clip circle is visible.
+  -->
+  <use clip-path="url(#myClip)" xlink:href="#heart" fill="red" />
+</svg>

--- a/test/samples/use.svg
+++ b/test/samples/use.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+  <circle id="myCircle" cx="5" cy="5" r="4"/>
+ 
+  <use href="#myCircle" x="20" fill="white" stroke="blue" />
+</svg>

--- a/test/unit/sanitize/filters/unique-id-prefix.js
+++ b/test/unit/sanitize/filters/unique-id-prefix.js
@@ -1,0 +1,56 @@
+/*globals describe, it*/
+require('should');
+
+describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
+  const traverse = require('traverse');
+  const prefixStyleClassnames =
+    require('../../../../lib/sanitize/filters/unique-svg-ids')({prefix: 'svgFilename__'});
+
+  it('should work on a simple tree', () => {
+    const tree = {
+      id: 'a',
+      fill: 'url(#a)',
+      mask: 'url(#a)',
+      xlinkHref: '#a'
+    };
+
+    var result = traverse.map(tree, prefixStyleClassnames);
+
+    result.
+      should.
+      eql({
+        id: 'svgFilename__a',
+        fill: 'url(#svgFilename__a)',
+        mask: 'url(#svgFilename__a)',
+        xlinkHref: '#svgFilename__a'
+      });
+  });
+
+  it('should work on a more complex tree', () => {
+    const tree = {
+      id: 'a',
+      id: 'b',
+      fill: 'url(#a)',
+      mask: 'url(#a)',
+      xlinkHref: '#a',
+      fill: 'url(#b)',
+      mask: 'url(#b)',
+      xlinkHref: '#b'
+    };
+
+    const result = traverse.map(tree, prefixStyleClassnames);
+
+    result.
+      should.
+      eql({
+        id: 'svgFilename__a',
+        fill: 'url(#svgFilename__a)',
+        mask: 'url(#svgFilename__a)',
+        xlinkHref: '#svgFilename__a',
+        id: 'svgFilename__b',
+        fill: 'url(#svgFilename__b)',
+        mask: 'url(#svgFilename__b)',
+        xlinkHref: '#svgFilename__b'
+      });
+  });
+});

--- a/test/unit/sanitize/filters/unique-id-prefix.js
+++ b/test/unit/sanitize/filters/unique-id-prefix.js
@@ -1,9 +1,9 @@
 /*globals describe, it*/
 require('should');
 
-describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
+describe('svg-react-loader/lib/sanitize/filters/unique-svg-ids', () => {
   const traverse = require('traverse');
-  const prefixStyleClassnames =
+  const prefixFilename =
     require('../../../../lib/sanitize/filters/unique-svg-ids')({prefix: 'svgFilename__'});
 
   it('should work on a simple tree', () => {
@@ -14,7 +14,7 @@ describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
       xlinkHref: '#a'
     };
 
-    var result = traverse.map(tree, prefixStyleClassnames);
+    var result = traverse.map(tree, prefixFilename);
 
     result.
       should.
@@ -40,7 +40,7 @@ describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
       }
     };
 
-    const result = traverse.map(tree, prefixStyleClassnames);
+    const result = traverse.map(tree, prefixFilename);
 
     result.
       should.
@@ -55,6 +55,26 @@ describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
           mask: 'url(#svgFilename__b)',
           xlinkHref: '#svgFilename__b'
         }
+      });
+  });
+
+  it('should not update values for fill, mask, or xlink:href if they are not references to IDs', () => {
+    const tree = {
+      id: 'c',
+      fill: '#fafafa',
+      mask: '#ae4d19',
+      xlinkHref: 'http://www.w3.org/1999/xlink'
+    };
+
+    const result = traverse.map(tree, prefixFilename);
+
+    result.
+      should.
+      eql({
+        id: 'svgFilename__c',
+        fill: '#fafafa',
+        mask: '#ae4d19',
+        xlinkHref: 'http://www.w3.org/1999/xlink'
       });
   });
 });

--- a/test/unit/sanitize/filters/unique-id-prefix.js
+++ b/test/unit/sanitize/filters/unique-id-prefix.js
@@ -29,13 +29,15 @@ describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
   it('should work on a more complex tree', () => {
     const tree = {
       id: 'a',
-      id: 'b',
       fill: 'url(#a)',
       mask: 'url(#a)',
       xlinkHref: '#a',
-      fill: 'url(#b)',
-      mask: 'url(#b)',
-      xlinkHref: '#b'
+      props: {
+        id: 'b',
+        fill: 'url(#b)',
+        mask: 'url(#b)',
+        xlinkHref: '#b'
+      }
     };
 
     const result = traverse.map(tree, prefixStyleClassnames);
@@ -47,10 +49,12 @@ describe('svg-react-loader/lib/sanitize/filters/prefix-style-class-id', () => {
         fill: 'url(#svgFilename__a)',
         mask: 'url(#svgFilename__a)',
         xlinkHref: '#svgFilename__a',
-        id: 'svgFilename__b',
-        fill: 'url(#svgFilename__b)',
-        mask: 'url(#svgFilename__b)',
-        xlinkHref: '#svgFilename__b'
+        props: {
+          id: 'svgFilename__b',
+          fill: 'url(#svgFilename__b)',
+          mask: 'url(#svgFilename__b)',
+          xlinkHref: '#svgFilename__b'
+        }
       });
   });
 });


### PR DESCRIPTION
Haven't had time to go back over this with a fine tooth comb since I made these changes, but it is working fine on two separate production sites at this point. It could be made more robust by implementing a 'usable' default prefix based on something like shortid, but that would meaning adding dependencies: see lib/sanitize/filters/unique-svg-ids.js at line line 7 for more info.