### PR TITLE
Fix the xmlnsTest option propagation

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -44,6 +44,8 @@ module.exports = function svgReactLoader (source) {
 
     if (typeof xmlnsTest === 'string') {
         options.xmlnsTest = new RegExp(xmlnsTest);
+    } else {
+        options.xmlnsTest = xmlnsTest;
     }
 
     if (Array.isArray(tagprops)) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,8 @@ module.exports = function (opts) {
             require('./sanitize/filters/convert-style-prop')(null),
             require('./sanitize/filters/prop-mapper')(options.propsMap),
             require('./sanitize/filters/camel-case-props')(null),
-            require('./sanitize/filters/remove-xmlns-props')(options.xmlnsTest)
+            require('./sanitize/filters/remove-xmlns-props')({test: options.xmlnsTest})
+
         );
 
     if (options.classIdPrefix) {

--- a/test/unit/sanitize/filters/remove-xmlns-props.js
+++ b/test/unit/sanitize/filters/remove-xmlns-props.js
@@ -1,0 +1,31 @@
+/*globals describe, it*/
+require('should');
+
+describe('svg-react-loader/lib/sanitize/filters/remove-xmlns-props', () => {
+    var removeXmlnsProps = require('../../../../lib/sanitize/filters/remove-xmlns-props');
+
+    it('should strip the matched props', () => {
+        const traverse = require('traverse');
+        const tree = {
+            tagname: 'svg',
+            props: {
+                xmlns1: "A",
+                xmlns2: "B",
+                inkscape1: "C",
+                width: "100",
+            },
+            children: []
+        };
+
+        var result = traverse.map(tree, removeXmlnsProps({test: /(xmlns|ink)/}));
+        result.
+            should.
+            eql({
+                tagname: 'svg',
+                props: {
+                    width: "100",
+                },
+                children: []
+            });
+    });
+});


### PR DESCRIPTION
This PR fixes two bugs and add a new test.

lib/loader.js takes in account the xmlnsTest option only if it was a string (and discard it if it is a regexp instance).

Moreover the xmlnTest option is passed to the filter as is (a regexp instance) but remove-xmlns-props wants an object with the `test` attribute.