### PR TITLE
Add ID and reference intepolation support, based on pull request #107

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 /node_modules/*
 /*.tgz
+.idea

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -68,8 +68,8 @@ module.exports = function svgReactLoader (source) {
     options.classIdPrefix =
         classIdPrefix === true ?
             displayName + '__' :
-            typeof classIdPref === 'string' ?
-                lutils.interpolatename(context, classIdPrefix) :
+            typeof classIdPrefix === 'string' ?
+                lutils.interpolateName(context, classIdPrefix, { content: source }) :
                 classIdPrefix;
 
     if (params.filters) {

--- a/lib/sanitize/filters/prefix-style-class-id.js
+++ b/lib/sanitize/filters/prefix-style-class-id.js
@@ -8,8 +8,11 @@ var DEFAULTS = {
     childrenKey: 'children'
 };
 
-var CLASSNAME_OR_ID_REGEX = /([a-zA-Z0-9_-]+)/g;
-var CLASSNAME_OR_ID_SELECTOR_REGEX = /([.#])([a-zA-Z0-9_-]+)/g;
+var _CLASSNAME_OR_ID_REGEX = '([a-zA-Z0-9_-]+)';
+var CLASSNAME_OR_ID_REGEX = new RegExp(_CLASSNAME_OR_ID_REGEX, 'g');
+var _CLASSNAME_OR_ID_SELECTOR_REGEX = '([.#])' + _CLASSNAME_OR_ID_REGEX;
+var CLASSNAME_OR_ID_SELECTOR_REGEX = new RegExp(_CLASSNAME_OR_ID_SELECTOR_REGEX, 'g');
+var URL_CLASSNAME_OR_ID_SELECTOR_REGEX = new RegExp('url\\(' + _CLASSNAME_OR_ID_SELECTOR_REGEX + '\\)', 'g')
 
 function processStyles (opts, source) {
     var ast = css.parse(source);
@@ -26,14 +29,18 @@ function processStyles (opts, source) {
                         replace(
                             CLASSNAME_OR_ID_SELECTOR_REGEX,
                             function (match, pre, post) {
-                                opts.cache[post] = opts.prefix + post;
-                                return pre + opts.prefix + post;
+                                opts.cache[post] = getName(opts, post);
+                                return pre + getName(opts, post);
                             }
                         );
                 });
         });
 
     return css.stringify(ast, { compress: true });
+}
+
+function getName(opts, originalName, cache) {
+    return cache && cache[originalName] || opts.prefix + originalName;
 }
 
 module.exports = function configrePrefixStyleClassId (opts) {
@@ -62,17 +69,24 @@ module.exports = function configrePrefixStyleClassId (opts) {
                     return child;
                 });
         }
-        else if (this.isLeaf && path[path.length - 1] === 'className') {
+        else if (this.isLeaf && ['className', 'id'].includes(path[path.length - 1] )) {
             this.update(
                 value.
                     replace(
                         CLASSNAME_OR_ID_REGEX,
                         function (m) {
-                            if (m in cache) {
-                                return cache[m];
-                            }
-
-                            return m;
+                            return getName(opts, m, cache);
+                        }
+                    )
+            );
+        }
+        else if (this.isLeaf && ['stroke', 'fill', 'href', 'xlink:href'].includes(path[path.length - 1] )) {
+            this.update(
+                value.
+                    replace(
+                        URL_CLASSNAME_OR_ID_SELECTOR_REGEX,
+                        function (m, pre, name) {
+                            return 'url(' + pre + getName(opts, name, cache) + ')';
                         }
                     )
             );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-react-loader",
-  "version": "0.4.6",
+  "version": "0.4.6-pre01",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-react-loader",
-  "version": "0.4.6",
+  "version": "0.4.6-pre01",
   "description": "A Webpack Loader to turn SVGs into React Components",
   "main": "./lib/loader.js",
   "directories": {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -5,7 +5,8 @@ import { mount } from 'enzyme';
 
 import SimpleSvg from '../../lib/loader.js?name=SimpleSvg!../samples/simple.svg';
 import StylesSvg from '../../lib/loader.js?classIdPrefix!../samples/styles.svg';
-import StylesInterpolation  from '../../lib/loader.js?classIdPrefix=my-prefix-[name]-[hash:5]-!../samples/styles.svg';
+import StylesInterpolation from '../../lib/loader.js?classIdPrefix=my-prefix-[name]-[hash:5]-!../samples/styles.svg';
+import ReferenceSvg from '../../lib/loader.js?name=SimpleSvg!../samples/reference.svg';
 
 import TextSvg from '../../lib/loader.js!../samples/text.svg';
 import ObjectSvg from '../../lib/loader.js!../samples/object.json';
@@ -13,149 +14,128 @@ import ObjectSvg from '../../lib/loader.js!../samples/object.json';
 require('should');
 
 const getPropsMinusChildren = R.pipe(
-    R.invoker(0, 'props'),
-    R.omit(['children'])
+  R.invoker(0, 'props'),
+  R.omit(['children'])
 );
 
 describe('svg-react-loader', () => {
+  const expectedSvgProps = {
+    version: '1.1',
+    x: '0px',
+    y: '0px',
+    viewBox: '0 0 16 16',
+    enableBackground: 'new 0 0 16 16',
+    xmlSpace: 'preserve',
+    className: 'simple'
+  };
 
-    const expectedSvgProps = {
-        version:          "1.1",
-        x:                "0px",
-        y:                "0px",
-        viewBox:          "0 0 16 16",
-        enableBackground: "new 0 0 16 16",
-        xmlSpace:         "preserve",
-        className:        "simple"
+  it('simple.svg', () => {
+    class Icon extends Component {
+      render() {
+        return <SimpleSvg />;
+      }
+    }
+
+    const wrapper = mount(<Icon />);
+
+    wrapper.containsMatchingElement(<svg {...expectedSvgProps} />).should.be
+      .true;
+
+    wrapper.containsMatchingElement(
+      <rect x="0" y="0" width="16" height="16" fill="#fff" />
+    ).should.be.true;
+
+    wrapper.containsMatchingElement(<text>Foobar</text>).should.be.true;
+  });
+
+  it('styles.svg', () => {
+    const wrapper = mount(<StylesSvg />);
+
+    const expectedProps = {
+      version: '1.1',
+      id: 'Layer_1',
+      width: '50px',
+      height: '50px',
+      x: '0px',
+      y: '0px',
+      viewBox: '0 0 50 50',
+      style: {
+        enableBackground: 'new 0 0 50 50'
+      },
+      xmlSpace: 'preserve',
+      preserveAspectRatio: 'none'
     };
 
-    it('simple.svg', () => {
+    getPropsMinusChildren(wrapper.find('svg')).should.eql(expectedProps);
 
-        class Icon extends Component {
-            render () {
-                return <SimpleSvg />;
-            }
-        };
+    wrapper.containsMatchingElement(<svg {...expectedProps} />).should.be.true;
 
-        const wrapper = mount(<Icon />);
+    wrapper
+      .childAt(0)
+      .text()
+      .should.equal(
+        '.Styles__st0{fill-rule:evenodd;clip-rule:evenodd;fill:#B2B2B2;}' +
+          ".Styles__foo{background:url('foo/bar/baz.jpg');}"
+      );
+  });
 
-        wrapper.
-            containsMatchingElement(<svg {...expectedSvgProps} />).
-            should.
-            be.
-            true;
+  it('styles.svg - with interpolation', () => {
+    const wrapper = mount(<StylesInterpolation />);
 
-        wrapper.
-            containsMatchingElement(<rect x="0" y="0" width="16" height="16" fill="#fff" />).
-            should.
-            be.
-            true;
+    if (!wrapper.html().match(/\.my-prefix-styles-1f3e1-foo/)) {
+      throw new Error('it should contain the interpolated className');
+    }
+    if (wrapper.html().match(/\[name]/)) {
+      throw new Error('should have [name] replaced with the filename');
+    }
+    if (wrapper.html().match(/\[hash:5]/)) {
+      throw new Error('should have [hash:5] replaced with a hash');
+    }
+  });
 
-        wrapper.
-            containsMatchingElement(<text>Foobar</text>).
-            should.
-            be.
-            true;
-    });
+  it('text.svg', () => {
+    const wrapper = mount(<TextSvg />);
 
-    it('styles.svg', () => {
-        const wrapper = mount(<StylesSvg />);
+    wrapper.containsMatchingElement(<svg />).should.be.true;
 
-        const expectedProps = {
-            version: "1.1",
-            id: "Layer_1",
-            width: "50px",
-            height: "50px",
-            x: "0px",
-            y: "0px",
-            viewBox: "0 0 50 50",
-            style: {
-                enableBackground: 'new 0 0 50 50'
-            },
-            xmlSpace: "preserve",
-            preserveAspectRatio: "none"
-        };
+    wrapper.containsMatchingElement(<title>The Title</title>).should.be.true;
 
-        getPropsMinusChildren(wrapper.find('svg')).
-            should.
-            eql(expectedProps);
+    wrapper.containsMatchingElement(
+      <text x="20" y="20">
+        Text
+      </text>
+    ).should.be.true;
+  });
 
-        wrapper.
-            containsMatchingElement(<svg {...expectedProps} />).
-            should.
-            be.
-            true;
+  it('object.svg', () => {
+    const wrapper = mount(<ObjectSvg />);
+    const expectedProps = {
+      viewBox: '0 0 16 16',
+      enableBackground: 'new 0 0 16 16',
+      xmlSpace: 'preserve'
+    };
 
-        wrapper.
-            childAt(0).
-            text().
-            should.
-            equal(
-                ".Styles__st0{fill-rule:evenodd;clip-rule:evenodd;fill:#B2B2B2;}" +
-                ".Styles__foo{background:url('foo/bar/baz.jpg');}"
-            );
-    });
+    wrapper.containsMatchingElement(<svg {...expectedProps} />).should.be.true;
 
-    it('styles.svg - with interpolation', () => {
-        const wrapper = mount(<StylesInterpolation />);
+    wrapper.containsMatchingElement(
+      <rect x="0" y="0" width="16" height="16" fill="#fff" />
+    ).should.be.true;
 
-        if (!wrapper.html().match(/\.my-prefix-styles-1f3e1-foo/)) {
-            throw new Error('it should contain the interpolated className')
-        }
-        if (wrapper.html().match(/\[name]/)) {
-            throw new Error('should have [name] replaced with the filename')
-        }
-        if (wrapper.html().match(/\[hash:5]/)) {
-            throw new Error('should have [hash:5] replaced with a hash')
-        }
-    });
+    wrapper.containsMatchingElement(<text>Foobar</text>).should.be.true;
+  });
 
-    it('text.svg', () => {
-        const wrapper = mount(<TextSvg />);
+  it('reference.svg', () => {
+    class Icon extends Component {
+      render() {
+        return <ReferenceSvg />;
+      }
+    }
 
-        wrapper.
-            containsMatchingElement(<svg />).
-            should.
-            be.
-            true;
+    const wrapper = mount(<Icon />);
 
-        wrapper.
-            containsMatchingElement(<title>The Title</title>).
-            should.
-            be.
-            true;
-
-        wrapper.
-            containsMatchingElement(<text x="20" y="20">Text</text>).
-            should.
-            be.
-            true;
-    });
-
-    it('object.svg', () => {
-        const wrapper = mount(<ObjectSvg />);
-        const expectedProps = {
-            "viewBox": "0 0 16 16",
-            "enableBackground": "new 0 0 16 16",
-            "xmlSpace": "preserve"
-        };
-
-        wrapper.
-            containsMatchingElement(<svg {...expectedProps} />).
-            should.
-            be.
-            true;
-
-        wrapper.
-            containsMatchingElement(<rect x="0" y="0" width="16" height="16" fill="#fff" />).
-            should.
-            be.
-            true;
-
-        wrapper.
-            containsMatchingElement(<text>Foobar</text>).
-            should.
-            be.
-            true;
-    });
+    wrapper
+      if (!wrapper.html().match(/#a/)) {
+        throw new Error('it should contain the interpolated className');
+      }
+  });
 });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -5,6 +5,8 @@ import { mount } from 'enzyme';
 
 import SimpleSvg from '../../lib/loader.js?name=SimpleSvg!../samples/simple.svg';
 import StylesSvg from '../../lib/loader.js?classIdPrefix!../samples/styles.svg';
+import StylesInterpolation  from '../../lib/loader.js?classIdPrefix=my-prefix-[name]-[hash:5]-!../samples/styles.svg';
+
 import TextSvg from '../../lib/loader.js!../samples/text.svg';
 import ObjectSvg from '../../lib/loader.js!../samples/object.json';
 
@@ -92,6 +94,20 @@ describe('svg-react-loader', () => {
                 ".Styles__st0{fill-rule:evenodd;clip-rule:evenodd;fill:#B2B2B2;}" +
                 ".Styles__foo{background:url('foo/bar/baz.jpg');}"
             );
+    });
+
+    it('styles.svg - with interpolation', () => {
+        const wrapper = mount(<StylesInterpolation />);
+
+        if (!wrapper.html().match(/\.my-prefix-styles-1f3e1-foo/)) {
+            throw new Error('it should contain the interpolated className')
+        }
+        if (wrapper.html().match(/\[name]/)) {
+            throw new Error('should have [name] replaced with the filename')
+        }
+        if (wrapper.html().match(/\[hash:5]/)) {
+            throw new Error('should have [hash:5] replaced with a hash')
+        }
     });
 
     it('text.svg', () => {

--- a/test/samples/reference.svg
+++ b/test/samples/reference.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px" y="0px"
+    viewBox="0 0 16 16"
+    enable-background="new 0 0 16 16"
+    xml:space="preserve"
+    class="simple"
+>
+  <defs><linearGradient id="a" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0" stop-color="#ffca11"></stop><stop offset="1" stop-color="#ffad27"></stop></linearGradient><polygon id="rating-star-colored-16bf8__ratingStar" points="14.910357 6.35294118 12.4209136 7.66171903 12.896355 4.88968305 10.8823529 2.92651626 13.6656353 2.52208166 14.910357 0 16.1550787 2.52208166 18.9383611 2.92651626 16.924359 4.88968305 17.3998004 7.66171903"></polygon></defs>
+  <rect x="0" y="0" width="16" height="16" fill="url(#a)" />
+</svg>

--- a/test/unit/xml/parse.js
+++ b/test/unit/xml/parse.js
@@ -135,7 +135,7 @@ describe('svg-react-loader/lib/xml/parse', () => {
                         eql({
                             props: {
                                 version:             '1.1',
-                                id:                  'Layer_1',
+                                id:                  'styles-test__Layer_1',
                                 width:               '50px',
                                 height:              '50px',
                                 x:                   '0px',


### PR DESCRIPTION
So I met issue #102 , and then found pull request #107 .

However, it cannot solve my problem completely, because the SVG file we get from designer might use ID and reference (contains "url(#a)") for complicated design request.

So I added this, but it got to base on #107 to work.