### PR TITLE
Passing displayName configuration to the filters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Rx = require('rx');
  */
 
 var pickStringifyOpts = R.pick(['displayName']);
-var pickSanitizeOpts = R.pick(['filters']);
+var pickSanitizeOpts = R.pick(['filters', 'displayName']);
 
 module.exports = R.curry(function svgToReact (opts, source) {
     var options   = require('./options')(opts);

--- a/lib/sanitize/index.js
+++ b/lib/sanitize/index.js
@@ -22,7 +22,7 @@ module.exports = R.curry(function sanitize (opts, tree) {
 
         filters.
             forEach(function (fn) {
-                fn.call(this, value);
+                fn.call(this, value, { displayName: opts.displayName });
             }, this);
     });
 });


### PR DESCRIPTION
There are certain filters that can benefit from high level configurations. 
A use case:
prefix some inner node's properties with the file name to prevent collisions like in the case of masks and clip paths