### PR TITLE
Bump ramda to 0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "css": "2.2.4",
     "loader-utils": "1.1.0",
-    "ramda": "0.21.0",
+    "ramda": "0.28.0",
     "rx": "4.1.0",
     "traverse": "0.6.6",
     "xml2js": "0.4.17"


### PR DESCRIPTION
Our project indirectly pulls ramda and our audit system flags v0.21.0.  Need to bump it to v0.28.0