### PR TITLE
Bump ramda to fix a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "css": "2.2.4",
     "loader-utils": "1.1.0",
-    "ramda": "0.21.0",
+    "ramda": "^0.27.1",
     "rx": "4.1.0",
     "traverse": "0.6.6",
     "xml2js": "0.4.17"


### PR DESCRIPTION
** DISPUTED ** Prototype poisoning in function mapObjIndexed in Ramda 0.27.0 and earlier allows attackers to compromise integrity or availability of application via supplying a crafted object (that contains an own property "proto") as an argument to the function. NOTE: the vendor disputes this because the observed behavior only means that a user can create objects that the user didn't know would contain custom prototypes.